### PR TITLE
Only push NuGet packages from 'main' and 'develop' builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           & dotnet pack --no-restore --configuration Release /bl:__artifacts/msbuild.release.binlog
 
-      - name: Test (debug)
+      - name: Test (release)
         shell: pwsh
         run: |
           & dotnet test --no-restore --configuration Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          fetch-depth: 0
           filter: blob:none
 
       - name: Setup .NET SDK

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
     paths-ignore:
       - '.editorconfig'
       - '.vscode/**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
           & dotnet test --no-restore --configuration Release
 
       - name: Publish packages
+        if: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/develop"]'), github.ref) }}
         shell: pwsh
         run: |
           & dotnet nuget add source --name github "https://nuget.pkg.github.com/mschofie/index.json"


### PR DESCRIPTION
Only push NuGet packages from 'main' and 'develop' builds, and a couple of other fixes:
1. Set 'fetch-depth: 0' to download full Git history for version height calculations - NerdBank Git Versioning needs history to calculate the 'height' since the last version edit.
2. Correct the name of the 'Test (release)' step