### PR TITLE
Update NuGet dependencies 7.0.1 --> 7.3.0; a few other small version bumps

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
-    <PackageVersion Include="NuGet.Commands" Version="7.0.1" />
-    <PackageVersion Include="NuGet.Common" Version="7.0.1" />
-    <PackageVersion Include="NuGet.Frameworks" Version="7.0.1" />
-    <PackageVersion Include="NuGet.Packaging" Version="7.0.1" />
-    <PackageVersion Include="NuGet.ProjectModel" Version="7.0.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="7.0.1" />
-    <PackageVersion Include="NuGet.Resolver" Version="7.0.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.2" />
+    <PackageVersion Include="NuGet.Commands" Version="7.3.0" />
+    <PackageVersion Include="NuGet.Common" Version="7.3.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.3.0" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="7.3.0" />
+    <PackageVersion Include="NuGet.Resolver" Version="7.3.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.3" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
Update to the latest NuGet Client SDK.

System.CommandLine, Microsoft.Extensions.Logging.Console and Microsoft.Extensions.Logging.Abstractions also got patch-level bumps.