### PR TITLE
Add the 'Create release and upload assets' job to create a release on 'main' CI builds

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -1,0 +1,38 @@
+Workflows
+=========
+
+Prefer `pwsh` for shell steps in GitHub Actions workflows for this repository.
+
+Why:
+
+- `pwsh` (PowerShell Core) runs consistently on GitHub-hosted Windows, macOS, and Linux runners.
+- Using `pwsh` avoids Windows-specific differences when a step is written in PowerShell, and reduces surprises when running the same workflow on multiple platforms.
+
+Guidance:
+
+- For PowerShell scripts use `shell: pwsh` and PowerShell syntax in the `run` block.
+- Only use `bash` when you need POSIX shell tools or syntax that isn't available in PowerShell.
+- If you choose a minimal runner (e.g. a custom `ubuntu-slim`), ensure `gh` or other required CLI tools are installed before use.
+
+Example:
+
+- name: Run PowerShell script
+  shell: pwsh
+  run: |
+    Write-Host "Hello from pwsh"
+
+Avoid embedding build logic in workflows
+---------------------------------------
+
+Where possible, keep build, packaging, and publishing logic inside the project/repository (e.g. MSBuild targets, dotnet CLI commands, or scripts versioned with the repo) rather than embedding that logic in GitHub Actions workflows.
+
+Why:
+
+- Easier to test locally and in CI (build logic lives with the code it builds).
+- One source of truth: build scripts and targets are reusable across CI providers and developer machines.
+- Simpler workflows: workflows should orchestrate (checkout, run build, upload artifacts), not duplicate complex build mechanics.
+
+When to use workflow logic:
+
+- Use workflows for orchestration, environment setup, and steps that are CI-specific (e.g., publishing to GitHub Packages with repo secrets).
+- If a small, portable helper is required only in CI, document it in this file and keep it minimal.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
         shell: pwsh
         run: |
           & dotnet nuget add source --name github "https://nuget.pkg.github.com/mschofie/index.json"
-          Get-ChildItem -Path __artifacts\package\release\MSchofie.*.nupkg |
+          Get-ChildItem -Path __artifacts/package/release/MSchofie.*.nupkg |
             ForEach-Object {
               & dotnet nuget push $_.FullName --api-key ${{ secrets.PACKAGE_PUBLISH_PAT }} --source "github"
             }
@@ -88,3 +88,65 @@ jobs:
           path: |
             __artifacts/msbuild.debug.binlog
             __artifacts/msbuild.release.binlog
+
+  create-release:
+    name: Create release and upload assets
+    needs: build
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      packages: write
+    if: ${{ github.event_name == 'push' && contains(fromJSON('["refs/heads/main"]'), github.ref) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          fetch-depth: 0
+          filter: blob:none
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Install .NET tools
+        shell: pwsh
+        run: |
+          dotnet tool restore
+
+      - name: Download package artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: __artifacts_package
+          path: __artifacts/package
+
+      - name: Get version
+        id: get_version
+        shell: pwsh
+        run: |
+          $Version = (& dotnet nbgv get-version --variable AssemblyInformationalVersion)
+          if (-not $Version) { Write-Error 'Version not found'; exit 1 }
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "version=$Version"
+
+      - name: Create release
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+        run: |
+          $Version = $env:VERSION
+          if (-not $Version) { Write-Error 'Version not found'; exit 1 }
+
+          Write-Host "Logging into gh"
+          Write-Output $env:GITHUB_TOKEN | gh auth login --with-token
+
+          Write-Host "Creating draft release '$Version'"
+          gh release create $Version --draft --title $Version --notes "" --latest=false
+
+          $files = Get-ChildItem -Path '__artifacts/package/release/MSchofie.*.nupkg' -ErrorAction SilentlyContinue
+          if (-not $files) { Write-Host "No .nupkg files found to upload"; exit 0 }
+          foreach ($file in $files) {
+            Write-Host "Uploading $($file.Name)"
+            gh release upload $Version $file.FullName --clobber
+          }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: write
-      packages: write
     if: ${{ github.event_name == 'push' && contains(fromJSON('["refs/heads/main"]'), github.ref) }}
     steps:
       - name: Checkout


### PR DESCRIPTION
For public consumption of nupkgs, without pushing to nuget.org, this PR hooks-up a GitHub Action Job to create a - draft! - release and add the built, release .nupkg files to it.

There's some documentation to help infer Agent direction when working on YAML workflows. There are common steps between the two jobs that would be great to share, but that's out-of-scope for now.

Buddy build here: <https://github.com/mschofie/NuNuGet/actions/runs/21966305135>