### PR TITLE
Release creation YAML should specify a 'target' for the release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,8 @@ jobs:
           $Version = $env:VERSION
           if (-not $Version) { Write-Error 'Version not found'; exit 1 }
 
+          $RefName = if ('${{ github.ref }}' -match 'refs/heads/(.*)') { $Matches[1] }
+
           Write-Host "Logging into gh"
           Write-Output $env:GITHUB_TOKEN | gh auth login --with-token
 
@@ -148,6 +150,9 @@ jobs:
             "--draft"
             if ($Version -match '-') {
               "--prerelease"
+            }
+            if ($RefName) {
+              "--target", $RefName
             }
             "--title", "v$Version"
             "--notes", ""


### PR DESCRIPTION
Fixes #13.

If the `.github\workflows\ci.yaml`'s 'Create release and upload assets' job is running on a ref that matches `refs/heads/(.*)`, then use the first sub-match (the branch name) as the `--target` parameter to `gh release create`.