### PR TITLE
Use 'StringComparer.OrdinalIgnoreCase' in the traversal index

### DIFF
--- a/NuNuGet/Traversal.cs
+++ b/NuNuGet/Traversal.cs
@@ -40,7 +40,8 @@ internal static class Traversal
                 {
                     LockFileDependency = dependency,
                     InDegree = dependency.Dependencies.Count,
-                });
+                },
+                StringComparer.OrdinalIgnoreCase);
 
         // Walk the index and populate the Consumers list for each entry.
         foreach (var (id, dependencyEntry) in index)

--- a/Tests/NuNuGet.Tests/TraversalTests.cs
+++ b/Tests/NuNuGet.Tests/TraversalTests.cs
@@ -163,4 +163,39 @@ public class TraversalTests
         Assert.True(indexOfC < indexOfA, "C should come before A");
         Assert.True(indexOfB < indexOfA, "B should come before A");
     }
+
+    [Fact]
+    public void CaseInsensitivePackageIds()
+    {
+        // Dependency references "b" in lowercase, but the package is declared as "B".
+        IEnumerable<(string, NuGetVersion)> result = Traversal.ReverseTopological(new PackagesLockFile
+        {
+            Targets = [
+                new PackagesLockFileTarget
+                {
+                    Dependencies =
+                    [
+                        new LockFileDependency
+                        {
+                            Id = "A",
+                            ResolvedVersion = NuGetVersion.Parse("1.0.0"),
+                            Dependencies =
+                            [
+                                new PackageDependency("b", VersionRange.Parse("2.0.0"))
+                            ]
+                        },
+                        new LockFileDependency
+                        {
+                            Id = "B",
+                            ResolvedVersion = NuGetVersion.Parse("2.0.0")
+                        },
+                    ]
+                }]
+        });
+
+        Assert.Equal(result, [
+            ("B", NuGetVersion.Parse("2.0.0")),
+            ("A", NuGetVersion.Parse("1.0.0")),
+        ]);
+    }
 }

--- a/Tests/NuNuGet.Tests/TraversalTests.cs
+++ b/Tests/NuNuGet.Tests/TraversalTests.cs
@@ -193,9 +193,9 @@ public class TraversalTests
                 }]
         });
 
-        Assert.Equal(result, [
+        Assert.Equal([
             ("B", NuGetVersion.Parse("2.0.0")),
             ("A", NuGetVersion.Parse("1.0.0")),
-        ]);
+        ], result);
     }
 }


### PR DESCRIPTION
Fixes #19.

As called out in #19, "Microsoft.Windows.SDK.CPP.x64" announces a dependency on "Microsoft.Windows.SDK.cpp" (lower case 'cpp'), but the NuGet package is called "Microsoft.Windows.SDK.CPP" (upper case 'CPP'). This breaks the topological sort in Traversal.ReverseTopological, since it builds an 'index' of the written packages.lock.json file with a default comparer for the `IDictionary<string, LockFileIndexEntry>`. The fix is to create the `IDictionary<string, LockFileIndexEntry>` implementation with `StringComparer.OrdinalIgnoreCase` comparer. Adding a test to verify the functionality.