### PR TITLE
Avoid a 'nuget.exe' dependency in ScenarioTests

### DIFF
--- a/Tests/NuNuGet.Tests/Helper.cs
+++ b/Tests/NuNuGet.Tests/Helper.cs
@@ -39,7 +39,7 @@ internal sealed class Helper
     public static void WriteFile(string path, string contents)
     {
         using StreamWriter outputFile = new StreamWriter(path);
-        outputFile.WriteLine(contents);
+        outputFile.Write(contents);
     }
 
     public static void Touch(string path)

--- a/Tests/NuNuGet.Tests/NuGetCli.cs
+++ b/Tests/NuNuGet.Tests/NuGetCli.cs
@@ -1,20 +1,54 @@
 namespace NuNuGet.Tests;
 
 using System;
+using System.IO;
+using System.Text.Json;
 
 using static NuNuGet.Tests.Helper;
 
-internal sealed class NuGetCli
+/// <summary>
+/// Abstraction for performing NuGet operations.
+/// </summary>
+internal interface INuGetCli
+{
+    /// <summary>
+    /// Adds a NuGet package to the specified local package source.
+    /// </summary>
+    /// <param name="packagePath">The file path to the <c>.nupkg</c> file to add.</param>
+    /// <param name="source">The root directory of the local NuGet package source.</param>
+    public void Add(string packagePath, string source);
+}
+
+/// <summary>
+/// Factory for creating the default <see cref="INuGetCli"/> implementation.
+/// </summary>
+internal static class NuGetCli
+{
+    /// <summary>
+    /// Creates the default <see cref="INuGetCli"/> implementation.
+    /// </summary>
+    /// <returns>A new <see cref="INuGetCli"/> instance.</returns>
+    public static INuGetCli Create()
+    {
+        return NuGetZipCli.Create();
+    }
+}
+
+/// <summary>
+/// Implements <see cref="INuGetCli"/> by shelling out to the <c>nuget.exe</c> CLI.
+/// </summary>
+internal sealed class NuGetExeCli : INuGetCli
 {
     private const string ExecutableName = "nuget.exe";
 
     private string ExecutablePath { get; }
 
-    private NuGetCli(string path)
+    internal NuGetExeCli(string path)
     {
         this.ExecutablePath = path;
     }
 
+    /// <inheritdoc />
     public void Add(string packagePath, string source)
     {
         ProcessResult result = ProcessManagement.RunProcess(this.ExecutablePath, $"add {packagePath} -Source {source}", Environment.CurrentDirectory);
@@ -24,9 +58,69 @@ internal sealed class NuGetCli
         }
     }
 
-    public static NuGetCli Create()
+    /// <summary>
+    /// Creates a new <see cref="NuGetExeCli"/> by locating <c>nuget.exe</c> on the system PATH.
+    /// </summary>
+    /// <returns>A new <see cref="INuGetCli"/> instance backed by <c>nuget.exe</c>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <c>nuget.exe</c> cannot be found on the PATH.</exception>
+    public static INuGetCli Create()
     {
         string path = FindOnPath(ExecutableName) ?? throw new InvalidOperationException($"Could not find {ExecutableName} on the system PATH.");
-        return new NuGetCli(path);
+        return new NuGetExeCli(path);
+    }
+}
+
+/// <summary>
+/// Implements <see cref="INuGetCli"/> by directly extracting the <c>.nupkg</c> zip archive
+/// and writing the required metadata files, without depending on <c>nuget.exe</c>.
+/// </summary>
+internal sealed partial class NuGetZipCli : INuGetCli
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.General) { WriteIndented = true };
+
+    internal NuGetZipCli()
+    {
+    }
+
+    /// <inheritdoc />
+    public void Add(string packagePath, string source)
+    {
+        // 1) Get the name and version from packagePath
+        (string packageName, string packageVersion) = NuGetSupport.GetPackageNameAndVersion(packagePath);
+        string lowerCasePackageName = packageName.ToLowerInvariant();
+
+        // 2) Make '<lower case packagename>/<version>' folder
+        string targetDir = Path.Combine(source, lowerCasePackageName, packageVersion);
+        CreateFolder(targetDir);
+
+        // 3) Copy the package to that folder, naming it '<lower case packagename>.<version>.nupkg'
+        string nupkgDestination = Path.Combine(targetDir, $"{lowerCasePackageName}.{packageVersion}.nupkg");
+        File.Copy(packagePath, nupkgDestination, overwrite: true);
+
+        // 4) Write '<lower case packagename>.<version>.nupkg.sha512' to the folder, containing the base64-encoded SHA512 hash of the package.
+        string packageHash = NuGetSupport.GetPackageSha512Hash(packagePath);
+        string sha512Path = Path.Combine(targetDir, $"{lowerCasePackageName}.{packageVersion}.nupkg.sha512");
+        WriteFile(sha512Path, packageHash);
+
+        // 5) Write '.nupkg.metadata' with the JSON:
+        //   {
+        //     "version": 2,
+        //     "contentHash": "<base64-encoded sha512 hash of the nupkg file>",
+        //   }
+        string metadataPath = Path.Combine(targetDir, ".nupkg.metadata");
+        string metadataJson = JsonSerializer.Serialize(new { version = 2, contentHash = packageHash }, JsonOptions);
+        WriteFile(metadataPath, metadataJson);
+
+        // 6) Extract the .nuspec file from the nupkg and write it to the folder as '<lower case packagename>.nuspec'
+        NuGetSupport.ExtractNuspec(packagePath, targetDir, packageName);
+    }
+
+    /// <summary>
+    /// Creates a new <see cref="NuGetZipCli"/> instance.
+    /// </summary>
+    /// <returns>A new <see cref="INuGetCli"/> instance that uses zip extraction.</returns>
+    public static INuGetCli Create()
+    {
+        return new NuGetZipCli();
     }
 }

--- a/Tests/NuNuGet.Tests/NuGetSupport.cs
+++ b/Tests/NuNuGet.Tests/NuGetSupport.cs
@@ -1,0 +1,66 @@
+namespace NuNuGet.Tests;
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+
+internal static partial class NuGetSupport
+{
+    [GeneratedRegex(@"^(?<name>.+)\.(?<version>\d+\.\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)?)$")]
+    private static partial Regex PackageNameVersionRegex();
+
+    /// <summary>
+    /// Gets the package name and version from a <c>.nupkg</c> file path.
+    /// </summary>
+    /// <remarks>
+    /// This method extracts the package name and version from the filename of the provided <c>.nupkg</c> file path,
+    /// without reading the package contents. A more rigorous implementation might read the <c>.nupkg</c> file as a
+    /// ZIP archive and extract the <c>.nuspec</c> file to read the package metadata, but this regex-based approach
+    /// is sufficient for the test scenarios in this project and avoids unnecessary file I/O.
+    /// </remarks>
+    /// <param name="packagePath">The file path to a <c>.nupkg</c> file.</param>
+    /// <returns>A tuple of the package name and version string.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the filename does not match the expected NuGet package naming pattern.</exception>
+    public static (string name, string version) GetPackageNameAndVersion(string packagePath)
+    {
+        string packageFileName = Path.GetFileNameWithoutExtension(packagePath);
+        Match match = PackageNameVersionRegex().Match(packageFileName);
+        if (!match.Success)
+        {
+            throw new InvalidOperationException($"Could not parse package name and version from '{packagePath}'.");
+        }
+
+        return (match.Groups["name"].Value, match.Groups["version"].Value);
+    }
+
+    /// <summary>
+    /// Computes the Base64-encoded SHA-512 hash of the specified NuGet package file.
+    /// </summary>
+    /// <param name="packagePath">The file path to the <c>.nupkg</c> file to hash.</param>
+    /// <returns>The Base64-encoded SHA-512 hash of the file contents.</returns>
+    public static string GetPackageSha512Hash(string packagePath)
+    {
+        using FileStream stream = File.OpenRead(packagePath);
+        byte[] hash = SHA512.HashData(stream);
+        return Convert.ToBase64String(hash);
+    }
+
+    /// <summary>
+    /// Extracts the <c>.nuspec</c> file from the specified <c>.nupkg</c> file and writes it to the target directory
+    /// with the name '&lt;lower case packagename&gt;.nuspec'.
+    /// </summary>
+    /// <param name="packagePath">The file path to the <c>.nupkg</c> file.</param>
+    /// <param name="targetPath">The directory where the <c>.nuspec</c> file should be written.</param>
+    /// <param name="packageName">The name of the package.</param>
+    /// <exception cref="InvalidOperationException">Thrown when the <c>.nuspec</c> file cannot be found in the package.</exception>
+    public static void ExtractNuspec(string packagePath, string targetPath, string packageName)
+    {
+        using ZipArchive archive = ZipFile.OpenRead(packagePath);
+        ZipArchiveEntry? nuspecEntry = archive.GetEntry($"{packageName}.nuspec") ?? throw new InvalidOperationException($"Could not find {packageName}.nuspec in {packagePath}.");
+        string lowerCasePackageName = packageName.ToLowerInvariant();
+        string nuspecDestination = Path.Combine(targetPath, $"{lowerCasePackageName}.nuspec");
+        nuspecEntry.ExtractToFile(nuspecDestination, overwrite: true);
+    }
+}

--- a/Tests/NuNuGet.Tests/NuGetSupportTests.cs
+++ b/Tests/NuNuGet.Tests/NuGetSupportTests.cs
@@ -1,0 +1,127 @@
+namespace NuNuGet.Tests;
+
+using System;
+using System.IO;
+using Xunit;
+
+public class NuGetSupportTests
+{
+    [Fact]
+    public void ParsePackageNameAndVersion_SimpleThreePartVersion()
+    {
+        (string name, string version) = NuGetSupport.GetPackageNameAndVersion("MyPackage.1.0.0.nupkg");
+
+        Assert.Equal("MyPackage", name);
+        Assert.Equal("1.0.0", version);
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_LargeVersionNumbers()
+    {
+        (string name, string version) = NuGetSupport.GetPackageNameAndVersion("MyPackage.10.200.3000.nupkg");
+
+        Assert.Equal("MyPackage", name);
+        Assert.Equal("10.200.3000", version);
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_DottedPackageName()
+    {
+        (string name, string version) = NuGetSupport.GetPackageNameAndVersion("System.Text.Json.9.0.0.nupkg");
+
+        Assert.Equal("System.Text.Json", name);
+        Assert.Equal("9.0.0", version);
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_PrereleaseVersion()
+    {
+        (string name, string version) = NuGetSupport.GetPackageNameAndVersion("MyPackage.1.0.0-beta.1.nupkg");
+
+        Assert.Equal("MyPackage", name);
+        Assert.Equal("1.0.0-beta.1", version);
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_DottedNameWithPrerelease()
+    {
+        (string name, string version) = NuGetSupport.GetPackageNameAndVersion("My.Complex.Package.2.3.4-rc.2.nupkg");
+
+        Assert.Equal("My.Complex.Package", name);
+        Assert.Equal("2.3.4-rc.2", version);
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_MultiSegmentPrerelease()
+    {
+        (string name, string version) = NuGetSupport.GetPackageNameAndVersion("MyPackage.1.0.0-beta.2.3.nupkg");
+
+        Assert.Equal("MyPackage", name);
+        Assert.Equal("1.0.0-beta.2.3", version);
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_FullPathIsHandled()
+    {
+        (string name, string version) = NuGetSupport.GetPackageNameAndVersion(Path.Combine("C:", "packages", "Newtonsoft.Json.13.0.3.nupkg"));
+
+        Assert.Equal("Newtonsoft.Json", name);
+        Assert.Equal("13.0.3", version);
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_NoVersionThrows()
+    {
+        _ = Assert.Throws<InvalidOperationException>(() =>
+            NuGetSupport.GetPackageNameAndVersion("NoVersion.nupkg"));
+    }
+
+    [Fact]
+    public void ParsePackageNameAndVersion_EmptyStringThrows()
+    {
+        _ = Assert.Throws<InvalidOperationException>(() =>
+            NuGetSupport.GetPackageNameAndVersion(".nupkg"));
+    }
+
+    [Fact]
+    public void GetPackageSha512Hash_ReturnsConsistentHash()
+    {
+        string tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, "test content for hashing");
+
+            string hash1 = NuGetSupport.GetPackageSha512Hash(tempFile);
+            string hash2 = NuGetSupport.GetPackageSha512Hash(tempFile);
+
+            Assert.NotEmpty(hash1);
+            Assert.Equal(hash1, hash2);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public void GetPackageSha512Hash_DifferentContentProducesDifferentHash()
+    {
+        string tempFile1 = Path.GetTempFileName();
+        string tempFile2 = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile1, "content A");
+            File.WriteAllText(tempFile2, "content B");
+
+            string hash1 = NuGetSupport.GetPackageSha512Hash(tempFile1);
+            string hash2 = NuGetSupport.GetPackageSha512Hash(tempFile2);
+
+            Assert.NotEqual(hash1, hash2);
+        }
+        finally
+        {
+            File.Delete(tempFile1);
+            File.Delete(tempFile2);
+        }
+    }
+}

--- a/Tests/NuNuGet.Tests/ScenarioTests.cs
+++ b/Tests/NuNuGet.Tests/ScenarioTests.cs
@@ -73,7 +73,7 @@ public class ScenarioTests
     [Fact]
     public void EndToEndScenario()
     {
-        NuGetCli nuGetCli = NuGetCli.Create();
+        INuGetCli nuGetCli = NuGetCli.Create();
 
         string nugetConfigPath = Path.Combine(this.ReferenceFolder, "nuget.config");
         string packagesListPath = Path.Combine(this.ReferenceFolder, "packages.list.json");


### PR DESCRIPTION
The ScenarioTests tests currently use 'nuget.exe' to build a package source - running "nuget add" to add the reference NuGet packages into the package source. Using 'nuget.exe' is an extra dependency, slower than manually laying out the packages, and makes validation on non-Windows OS's much harder. This PR adds an interface to abstract 'nuget cli' operations, and provides two implementations - one that unpacks/writes files manually, and one that uses nuget.exe (a reference implementation to validate the manual implementation).