### PR TITLE
Verify Linux functionality during CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.cs]
+indent_size = 4
+tab_width = 4
 csharp_indent_labels = one_less_than_current
 csharp_prefer_braces = true:silent
 csharp_prefer_simple_default_expression = true:suggestion
@@ -64,10 +66,6 @@ dotnet_style_qualification_for_event = true
 dotnet_style_qualification_for_field = true
 dotnet_style_qualification_for_method = true
 dotnet_style_qualification_for_property = true
-end_of_line = crlf
-indent_size = 4
-indent_style = space
-tab_width = 4
 csharp_style_prefer_method_group_conversion = true:silent
 csharp_style_prefer_top_level_statements = false:silent
 dotnet_analyzer_diagnostic.severity = warning
@@ -97,6 +95,8 @@ dotnet_diagnostic.IDE0161.severity = warning
 dotnet_diagnostic.xUnit2001.severity = warning
 
 [*.{cs,vb}]
+indent_size = 4
+tab_width = 4
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
@@ -141,6 +141,3 @@ dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_readonly_field = true
 dotnet_style_require_accessibility_modifiers = always
-tab_width = 4
-indent_size = 4
-end_of_line = crlf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,17 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 jobs:
   build:
-    name: Build
-    runs-on: windows-2025
+    name: Build (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-2025]
+        include:
+          - os: ubuntu-22.04
+            checkFormatting: true
+          - os: windows-2025
+            publishPackages: true
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -33,6 +42,7 @@ jobs:
           & dotnet restore
 
       - name: Check formatting
+        if: ${{ matrix.checkFormatting }}
         shell: pwsh
         run: |
           & dotnet format --no-restore --verify-no-changes
@@ -58,7 +68,7 @@ jobs:
           & dotnet test --no-restore --configuration Release
 
       - name: Publish packages
-        if: ${{ contains(fromJSON('["refs/heads/main", "refs/heads/develop"]'), github.ref) }}
+        if: ${{ matrix.publishPackages && contains(fromJSON('["refs/heads/main", "refs/heads/develop"]'), github.ref) }}
         shell: pwsh
         run: |
           & dotnet nuget add source --name github "https://nuget.pkg.github.com/mschofie/index.json"
@@ -70,14 +80,14 @@ jobs:
       - name: Upload 'package' artifact
         uses: actions/upload-artifact@v7
         with:
-          name: __artifacts_package
+          name: __artifacts_package_${{ matrix.os }}
           path: |
             __artifacts/package
 
       - name: Upload 'msbuild_binlog' artifact
         uses: actions/upload-artifact@v7
         with:
-          name: __artifacts_msbuild_binlog
+          name: __artifacts_msbuild_binlog_${{ matrix.os }}
           path: |
             __artifacts/msbuild.debug.binlog
             __artifacts/msbuild.release.binlog
@@ -103,7 +113,7 @@ jobs:
       - name: Download package artifact
         uses: actions/download-artifact@v8
         with:
-          name: __artifacts_package
+          name: __artifacts_package_windows-2025
           path: __artifacts/package
 
       - name: Get version

--- a/Tests/NuNuGet.Tests/ScenarioTests.cs
+++ b/Tests/NuNuGet.Tests/ScenarioTests.cs
@@ -8,6 +8,8 @@ using static NuNuGet.Tests.Helper;
 
 public class ScenarioTests
 {
+    private readonly ITestOutputHelper output;
+
     private string ReferenceFolder { get; }
 
     private string OutputFolder { get; }
@@ -20,8 +22,10 @@ public class ScenarioTests
 
     private string ConfigFilePath { get; }
 
-    public ScenarioTests()
+    public ScenarioTests(ITestOutputHelper output)
     {
+        this.output = output;
+
         this.OutputFolder = Path.GetDirectoryName(typeof(ScenarioTests).Assembly.Location)!;
         this.RepositoryRoot = Git.GetRepositoryRoot(this.OutputFolder);
         this.ReferenceFolder = Path.Combine(this.RepositoryRoot, "Tests", "NuNuGet.Tests", "Reference");
@@ -36,6 +40,7 @@ public class ScenarioTests
 
     private ProcessResult RunNuNuGet(params string[] args)
     {
+        this.output.WriteLine($"Running '{this.NuNuGetPath} {string.Join(' ', args)}' in folder '{this.OutputFolder}'");
         return ProcessManagement.RunProcess(this.NuNuGetPath, string.Join(' ', args), this.OutputFolder);
     }
 

--- a/Tests/NuNuGet.Tests/ScenarioTests.cs
+++ b/Tests/NuNuGet.Tests/ScenarioTests.cs
@@ -25,12 +25,13 @@ public class ScenarioTests
         this.OutputFolder = Path.GetDirectoryName(typeof(ScenarioTests).Assembly.Location)!;
         this.RepositoryRoot = Git.GetRepositoryRoot(this.OutputFolder);
         this.ReferenceFolder = Path.Combine(this.RepositoryRoot, "Tests", "NuNuGet.Tests", "Reference");
-        this.NuNuGetPath = Path.Combine(this.OutputFolder, "NuNuGet.exe");
         this.BuiltPackagesFolder = Path.Combine(this.RepositoryRoot, "__artifacts", "package", Build.GetConfiguration().ToLowerInvariant());
-
         this.ConfigFilePath = Path.Combine(this.ReferenceFolder, "nuget.config");
 
-        Assert.True(File.Exists(this.NuNuGetPath), $"Expected NuNuGet.exe to be present in the working folder: {this.OutputFolder}");
+        string nunugetExecutableName = OperatingSystem.IsWindows() ? "NuNuGet.exe" : "NuNuGet";
+        this.NuNuGetPath = Path.Combine(this.OutputFolder, nunugetExecutableName);
+
+        Assert.True(File.Exists(this.NuNuGetPath), $"Expected {nunugetExecutableName} to be present in the working folder: {this.OutputFolder}");
     }
 
     private ProcessResult RunNuNuGet(params string[] args)


### PR DESCRIPTION
Some small 'cross-platform' fixes;
1. Choose 'NuNuGet' or 'NuNuGet.exe' for the executable to test based on OS.
2. Fix .editorconfig to not always require CRLF line endings
3. Add 'ITestOutputHelper' in ScenarioTests, write logs to help debuggability.

And then split the CI job across `ubuntu-22.04` and `windows-2025` images.
