### PR TITLE
Run scenario tests with 'NUGET_PACKAGES' clear; validate 'GlobalPackagesPath' output

### DIFF
--- a/Tests/NuNuGet.Tests/Git.cs
+++ b/Tests/NuNuGet.Tests/Git.cs
@@ -12,7 +12,12 @@ public static class Git
     /// <exception cref="InvalidOperationException">Thrown when the repository root cannot be determined.</exception>
     public static string GetRepositoryRoot(string fromPath)
     {
-        ProcessResult result = ProcessManagement.RunProcess("git", $"-C {fromPath} rev-parse --show-toplevel", fromPath);
+        ProcessManagement processManagement = new ProcessManagement()
+        {
+            WorkingDirectory = fromPath,
+        };
+
+        ProcessResult result = processManagement.Run("git", $"rev-parse --show-toplevel");
 
         if (result.ExitCode != 0)
         {

--- a/Tests/NuNuGet.Tests/NuGetCli.cs
+++ b/Tests/NuNuGet.Tests/NuGetCli.cs
@@ -41,6 +41,8 @@ internal sealed class NuGetExeCli : INuGetCli
 {
     private const string ExecutableName = "nuget.exe";
 
+    private ProcessManagement ProcessManagement { get; } = new ProcessManagement();
+
     private string ExecutablePath { get; }
 
     internal NuGetExeCli(string path)
@@ -51,7 +53,7 @@ internal sealed class NuGetExeCli : INuGetCli
     /// <inheritdoc />
     public void Add(string packagePath, string source)
     {
-        ProcessResult result = ProcessManagement.RunProcess(this.ExecutablePath, $"add {packagePath} -Source {source}", Environment.CurrentDirectory);
+        ProcessResult result = this.ProcessManagement.Run(this.ExecutablePath, $"add {packagePath} -Source {source}");
         if (result.ExitCode != 0)
         {
             throw new InvalidOperationException($"Failed to add package: {result.StandardOutput}\n {result.StandardError}\n");

--- a/Tests/NuNuGet.Tests/ProcessManagement.cs
+++ b/Tests/NuNuGet.Tests/ProcessManagement.cs
@@ -17,14 +17,23 @@ internal sealed class ProcessManagement
 {
     public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
+    public TimeSpan Timeout { get; set; } = DefaultTimeout;
+
+    public string WorkingDirectory { get; set; } = Environment.CurrentDirectory;
+
+    public IDictionary<string, string?> EnvironmentVariables { get; } = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+    public ProcessManagement()
+    {
+    }
+
     /// <summary>
     /// Runs a process with the given arguments.
     /// </summary>
     /// <param name="exePath">Executable path</param>
     /// <param name="arguments">Process arguments</param>
-    /// <param name="workingDirectory">The working directory of the process</param>
     /// <returns>The result of the process execution.</returns>
-    public static ProcessResult RunProcess(string exePath, string arguments, string workingDirectory)
+    public ProcessResult Run(string exePath, string arguments)
     {
         ProcessStartInfo startInfo = new(exePath)
         {
@@ -32,16 +41,21 @@ internal sealed class ProcessManagement
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            WorkingDirectory = workingDirectory,
+            WorkingDirectory = this.WorkingDirectory,
         };
 
-        return ProcessManagement.RunProcess(startInfo, DefaultTimeout);
-    }
+        foreach ((string name, string? value) in this.EnvironmentVariables)
+        {
+            if (value is null)
+            {
+                _ = startInfo.Environment.Remove(name);
+            }
+            else
+            {
+                startInfo.Environment[name] = value;
+            }
+        }
 
-    public static ProcessResult RunProcess(ProcessStartInfo startInfo) => ProcessManagement.RunProcess(startInfo, DefaultTimeout);
-
-    public static ProcessResult RunProcess(ProcessStartInfo startInfo, TimeSpan timeout)
-    {
         StringBuilder outputBuffer = new();
         StringBuilder errorBuffer = new();
 
@@ -71,10 +85,10 @@ internal sealed class ProcessManagement
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
 
-        bool exited = process.WaitForExit(timeout);
+        bool exited = process.WaitForExit(this.Timeout);
         if (!exited)
         {
-            throw new TimeoutException($"Process did not exit within the timeout of {timeout.TotalSeconds} seconds: ProcessName={process.ProcessName} HasExited={process.HasExited}");
+            throw new TimeoutException($"Process did not exit within the timeout of {this.Timeout.TotalSeconds} seconds: ProcessName={process.ProcessName} HasExited={process.HasExited}");
         }
 
         // Process.WaitForExit(int) will not wait for asynchronous processing to complete. If that overload

--- a/Tests/NuNuGet.Tests/ScenarioTests.cs
+++ b/Tests/NuNuGet.Tests/ScenarioTests.cs
@@ -29,7 +29,7 @@ public class ScenarioTests
         this.output = output;
 
         this.OutputFolder = Path.GetDirectoryName(typeof(ScenarioTests).Assembly.Location)!;
-        this.RepositoryRoot = Git.GetRepositoryRoot(this.OutputFolder);
+        this.RepositoryRoot = Path.GetFullPath(Git.GetRepositoryRoot(this.OutputFolder));
         this.ReferenceFolder = Path.Combine(this.RepositoryRoot, "Tests", "NuNuGet.Tests", "Reference");
         this.BuiltPackagesFolder = Path.Combine(this.RepositoryRoot, "__artifacts", "package", Build.GetConfiguration().ToLowerInvariant());
         this.ConfigFilePath = Path.Combine(this.ReferenceFolder, "nuget.config");

--- a/Tests/NuNuGet.Tests/ScenarioTests.cs
+++ b/Tests/NuNuGet.Tests/ScenarioTests.cs
@@ -10,6 +10,8 @@ public class ScenarioTests
 {
     private readonly ITestOutputHelper output;
 
+    private ProcessManagement ProcessManagement { get; } = new ProcessManagement();
+
     private string ReferenceFolder { get; }
 
     private string OutputFolder { get; }
@@ -35,13 +37,15 @@ public class ScenarioTests
         string nunugetExecutableName = OperatingSystem.IsWindows() ? "NuNuGet.exe" : "NuNuGet";
         this.NuNuGetPath = Path.Combine(this.OutputFolder, nunugetExecutableName);
 
+        this.ProcessManagement.WorkingDirectory = this.OutputFolder;
+
         Assert.True(File.Exists(this.NuNuGetPath), $"Expected {nunugetExecutableName} to be present in the working folder: {this.OutputFolder}");
     }
 
     private ProcessResult RunNuNuGet(params string[] args)
     {
         this.output.WriteLine($"Running '{this.NuNuGetPath} {string.Join(' ', args)}' in folder '{this.OutputFolder}'");
-        return ProcessManagement.RunProcess(this.NuNuGetPath, string.Join(' ', args), this.OutputFolder);
+        return this.ProcessManagement.Run(this.NuNuGetPath, string.Join(' ', args));
     }
 
     [Fact]

--- a/Tests/NuNuGet.Tests/ScenarioTests.cs
+++ b/Tests/NuNuGet.Tests/ScenarioTests.cs
@@ -38,6 +38,7 @@ public class ScenarioTests
         this.NuNuGetPath = Path.Combine(this.OutputFolder, nunugetExecutableName);
 
         this.ProcessManagement.WorkingDirectory = this.OutputFolder;
+        this.ProcessManagement.EnvironmentVariables["NUGET_PACKAGES"] = null;
 
         Assert.True(File.Exists(this.NuNuGetPath), $"Expected {nunugetExecutableName} to be present in the working folder: {this.OutputFolder}");
     }
@@ -89,6 +90,7 @@ public class ScenarioTests
         string packagesListPath = Path.Combine(this.ReferenceFolder, "packages.list.json");
         string packagesLockPath = Path.Combine(this.ReferenceFolder, "packages.lock.json");
         string packageSourcePath = Path.Combine(this.ReferenceFolder, "__packages");
+        string globalPackagesPath = Path.Combine(this.ReferenceFolder, "__global_packages");
 
         string package050 = Path.Combine(this.BuiltPackagesFolder, "NuNuGet.Reference.0.5.0.nupkg");
         string package060 = Path.Combine(this.BuiltPackagesFolder, "NuNuGet.Reference.0.6.0.nupkg");
@@ -98,10 +100,14 @@ public class ScenarioTests
         //  - Create the 'nuget.config' file, and add the local package source to it.
         //  - Create the 'packages.list.json' file, and add NuNuGet.Reference.0.5 to it.
         //  - Delete the 'packageSourcePath', recreate it, and add NuNuGet.Reference.0.5 to it.
+        //  - Delete the 'globalPackagesPath', recreate it.
         DeleteFile(packagesLockPath);
         WriteFile(nugetConfigPath, $$"""
             <?xml version="1.0" encoding="utf-8"?>
             <configuration>
+                <config>
+                    <add key="globalPackagesFolder" value="{{globalPackagesPath}}" />
+                </config>
                 <packageSources>
                     <clear />
                     <add key="store" value="{{packageSourcePath}}" />
@@ -120,11 +126,15 @@ public class ScenarioTests
         CreateFolder(packageSourcePath);
         nuGetCli.Add(package050, packageSourcePath);
 
+        RemoveFolder(globalPackagesPath);
+        CreateFolder(globalPackagesPath);
+
         // Act: Run NuNuGet.exe to generate the lock file.
         {
             ProcessResult processResult = this.RunNuNuGet("install", "--configFile", nugetConfigPath, "--lockFile", packagesLockPath, "--listFile", packagesListPath);
 
             Assert.Equal(0, processResult.ExitCode);
+            Assert.Contains($"GlobalPackagesPath: {globalPackagesPath}", processResult.StandardOutput);
             Assert.Contains("NuNuGet.Reference/0.5.0", processResult.StandardOutput);
         }
 


### PR DESCRIPTION
Before adding tests for PackageSourceMappings, the 'GlobalPackagesPath' needs to be canonicalized a little. The current scenario tests use the global packages path that is configured based on the machine environment. In order to test PackageSourceMappings we'll need to clean the global packages path, and cleaning the machine-environment-configured global packages path is a bit rude. This PR edits the current scenario test to add the `globalPackagesFolder` configuration to the `nuget.config` file used for the tests to force the tests to use a controlled global packages path.

In order to force use of the nuget.config-specified global packages path, the tests need to ensure that NuNuGet.exe is invoked with `NUGET_PACKAGES` cleared from the environment, otherwise `NUGET_PACKAGES` is preferred. So there's a bunch of reshuffling to accommodate passing environment variables through `ProcessManagement`.