### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.os }})
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/mschofie/NuNuGet/security/code-scanning/2](https://github.com/mschofie/NuNuGet/security/code-scanning/2)

In general, the fix is to explicitly declare `permissions` for the job (or at the workflow root) so that the `GITHUB_TOKEN` has only the minimal required scopes. For this `build` job, all operations are local (dotnet restore/build/test, NuGet push with a PAT, artifact upload), and only need read access to the repository contents. Therefore, we can safely set `permissions: contents: read` on the `build` job.

The best fix with minimal functional impact is to add a `permissions` block inside the `build` job definition, alongside `name`, `strategy`, `runs-on`, etc. Specifically, in `.github/workflows/ci.yaml` under `jobs: build:`, insert:

```yaml
    permissions:
      contents: read
```

This will ensure the `GITHUB_TOKEN` used in that job is limited to read access to repository contents while leaving the existing `create-release` job’s explicit `contents: write` unchanged. No additional imports, tools, or code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
