### PR TITLE
Add 'main' branch to CodeQL workflow triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main", "develop" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main", "develop" ]
   schedule:
     - cron: '28 5 * * 5'
 


### PR DESCRIPTION
## Summary
Extend the CodeQL Advanced workflow to also run on the `main` branch, in addition to `develop`.

## Changes
- Updated `.github/workflows/codeql.yml` push trigger to include both `main` and `develop` branches
- Updated `.github/workflows/codeql.yml` pull_request trigger to include both `main` and `develop` branches

## Motivation
Ensures CodeQL security analysis runs on `main` as well, providing coverage for the primary release branch.