### PR TITLE
Add nuget and dotnet-sdk package ecosystems to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
         patterns:
           - "Nerdbank.GitVersioning"
           - "nbgv"
+
+  - package-ecosystem: dotnet-sdk
+    directory: '/'
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,19 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+
+  - package-ecosystem: nuget
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      nuget:
+        patterns:
+          - "NuGet*"
+      xunit:
+        patterns:
+          - "xunit*"
+      gitversioning:
+        patterns:
+          - "Nerdbank.GitVersioning"
+          - "nbgv"


### PR DESCRIPTION
## Summary
- Add `nuget` package-ecosystem to dependabot with grouped updates for NuGet packages, xunit, and Nerdbank.GitVersioning/nbgv
- Add `dotnet-sdk` package-ecosystem to dependabot for weekly SDK updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)