### PR TITLE
Fix '.github/workflows/scorecard.yml' ossf/scorecard-action version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,7 +2,6 @@ name: OpenSSF Scorecard
 on:
   push:
     branches:
-      - main
       - develop
   workflow_dispatch:
   schedule:
@@ -25,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
`.github/workflows/scorecard.yml` specifies the incorrect version for `ossf/scorecard-action`. It's tricky to test the workflow, since it can't be scheduled until it's in the 'default' branch. And #37 got the workflow into the default branch. So now I can schedule it and discover the version is wrong. And then schedule a test, and _that_ complains with "Only the default branch develop is supported.". So I think I have to complete this PR to get things into `develop` and hope that a scorecard is generated...? Let's see how it goes...