### PR TITLE
Fix '.github/workflows/scorecard.yml' ossf/scorecard-action permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,17 +6,19 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '15 6 * * 1'
-
-permissions:
-  contents: read
-  actions: read
-  security-events: write
-  id-token: write
-
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    permissions:
+      # Required when publishing results (badge / API / code scanning)
+      security-events: write
+      id-token: write
+      # Recommended reads for private repos to avoid GraphQL/SAST gaps
+      contents: read
+      issues: read
+      pull-requests: read
+      checks: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
OK, #38 fixed the scorecard workflow's version, now we need to fix the permissions. This PR lifts the permissions from the [documentation](https://github.com/ossf/scorecard-action#workflow-restrictions). That should do the trick..? It's really frustrating that there doesn't appear to be a way to buddy test this.