### PR TITLE
Move 'publishPackages' from 'windows-2025' to 'ubuntu-22.04'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
         include:
           - os: ubuntu-22.04
             checkFormatting: true
-          - os: windows-2025
             publishPackages: true
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The 'ubuntu-22.04' job of the CI/PR build is much faster than the 'windows-2025' job (1m 52s vs. 3m 24s, from [a recent run](https://github.com/mschofie/NuNuGet/actions/runs/22973595780)). To try and even things out a little, this PR moves the package publishing step from 'windows-2025' to 'ubuntu-22.04'. This _might_ get the 'windows-2025' build to hit the 3m mark...? 🤞 