### PR TITLE
Pin GitHub Actions to commit hashes for supply chain security

### DIFF
--- a/.github/actions/machine-setup/action.yml
+++ b/.github/actions/machine-setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       with:
         global-json-file: global.json
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           lfs: false
           fetch-depth: 0
@@ -79,14 +79,14 @@ jobs:
             }
 
       - name: Upload 'package' artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: __artifacts_package_${{ matrix.os }}
           path: |
             __artifacts/package
 
       - name: Upload 'msbuild_binlog' artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: __artifacts_msbuild_binlog_${{ matrix.os }}
           path: |
@@ -102,7 +102,7 @@ jobs:
     if: ${{ github.event_name == 'push' && contains(fromJSON('["refs/heads/main"]'), github.ref) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           lfs: false
           fetch-depth: 0
@@ -112,7 +112,7 @@ jobs:
         uses: ./.github/actions/machine-setup
 
       - name: Download package artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: __artifacts_package_windows-2025
           path: __artifacts/package

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,18 +21,18 @@ jobs:
       checks: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Replace all tag-based GitHub Action references with their corresponding commit SHAs
- Tag name preserved as a trailing comment (e.g. `# v6`) for readability
- Affects `ci.yaml`, `codeql.yml`, `scorecard.yml`, and the `machine-setup` composite action

## Pinned actions
| Action | Tag | Commit SHA |
|--------|-----|------------|
| `actions/checkout` | `v6` | `de0fac2e` |
| `actions/setup-dotnet` | `v5` | `c2fa09f4` |
| `actions/upload-artifact` | `v7` | `bbbca2dd` |
| `actions/download-artifact` | `v8` | `3e5f45b2` |
| `github/codeql-action/{init,analyze,upload-sarif}` | `v4` | `0d579ffd` |
| `ossf/scorecard-action` | `v2.4.3` | `4eaacf05` |

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm CodeQL and Scorecard workflows still run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)