### PR TITLE
Update NuGet packages to 7.6.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,16 +2,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
-    <PackageVersion Include="NuGet.Commands" Version="7.3.1" />
-    <PackageVersion Include="NuGet.Common" Version="7.3.1" />
-    <PackageVersion Include="NuGet.Packaging" Version="7.3.1" />
-    <PackageVersion Include="NuGet.ProjectModel" Version="7.3.1" />
-    <PackageVersion Include="NuGet.Resolver" Version="7.3.1" />
-    <PackageVersion Include="System.CommandLine" Version="2.0.7" />
+    <PackageVersion Include="NuGet.Commands" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Common" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="7.6.0" />
+    <PackageVersion Include="NuGet.Resolver" Version="7.6.0" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.8" />
     <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="10.0.2" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
NuGet 7.6.0 packages were released a few days ago. Updating to them. This PR updates:

* Microsoft.Extensions.Logging.Abstractions
* Microsoft.Extensions.Logging.Console
  * 10.0.7 --> 10.0.8
* System.CommandLine
  * 2.0.7 --> 2.0.8
* NuGet.Commands
* NuGet.Common
* NuGet.Packaging
* NuGet.ProjectModel
* NuGet.Resolver
  * 7.3.1 --> 7.6.0
