### PR TITLE
Grant 'packages: write' permissions for 'Publish packages'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       actions: write
+      packages: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The CI build is failing on 'main': https://github.com/mschofie/NuNuGet/actions/runs/27515827340

It looks like the 'Publish packages' step needs `packages: write` permissions.